### PR TITLE
Kreisverband Rhein-Erft in constants.php einfügen

### DIFF
--- a/inc/constants.php
+++ b/inc/constants.php
@@ -589,6 +589,7 @@ $default_toplink_liste = array(
          '<abbr title="Kreisverband">KV</abbr> Krefeld' =>'http://wiki.piratenpartei.de/NRW:Krefeld/Kreisverband',
          '<abbr title="Kreisverband">KV</abbr> Minden-L&uuml;bbecke' =>'http://wiki.piratenpartei.de/NRW:Kreis_Minden-L%C3%BCbbecke/Kreisverband',
          '<abbr title="Kreisverband">KV</abbr> M&uuml;nster' =>'http://www.piratenpartei-muenster.de/',
+         '<abbr title="Kreisverband">KV</abbr> Rhein-Erft' =>'http://piratenpartei-rhein-erft.de/',
          '<abbr title="Kreisverband">KV</abbr> Rhein-Sieg-Kreis' =>'http://wiki.piratenpartei.de/NRW:Rhein-Sieg-Kreis',
          '<abbr title="Kreisverband">KV</abbr> Soest' =>'http://www.piratenpartei-soest.de/',
          '<abbr title="Kreisverband">KV</abbr> Wesel' =>'http://wiki.piratenpartei.de/NRW:Kreis_Wesel',


### PR DESCRIPTION
Ahoi,

heute hat sich der Kreisverband Rhein-Erft gegründet, der sollte dann auch in inc/constants.php eingefügt werden.

Viele Grüße
Piratonym
