### PR TITLE
fix numentries linktipps

### DIFF
--- a/home.php
+++ b/home.php
@@ -152,8 +152,6 @@
 		 $z=1;
 		 query_posts(  array( 'post_type' => array('linktipps'), 'posts_per_page' => $numentries ) ); 
 		 global $post;
-		 
-		 $numentries = $options['artikelstream-maxnum-main'] + $options['artikelstream-nextnum-main'];
   
 		 
 		 $linktippout .= '<div class="columns">';


### PR DESCRIPTION
Es werden nicht alle Linktipss angezeigt, wenn die Anzahl der anzuzeigenden Beiträge im Hauptartikelstrom kleiner ist als die von den Linktipps
