### PR TITLE
Anpassung des Kategorien- und Seitenindex für aktuelle WordPress-Versionen

### DIFF
--- a/templates/category-index.php
+++ b/templates/category-index.php
@@ -50,7 +50,7 @@
         $subcatquery = array(); 
 	if ($cat_array) {
 	  foreach($cat_array as $cat) {
-		$category = get_term_by('ID',$cat, 'category');
+		$category = get_term_by('id',$cat, 'category');
                 $title = '<h2>' . $category->name.'</h2>';
                 
                 $subcatquery =array(

--- a/templates/pageindex.php
+++ b/templates/pageindex.php
@@ -46,7 +46,7 @@
         $subcatquery = array(); 
 	if ($cat_array) {
 	  foreach($cat_array as $cat) {
-		$category = get_term_by('ID',$cat, 'category');
+		$category = get_term_by('id',$cat, 'category');
                 $title = '<h2>' . $category->name.'</h2>';
                 
                 $subcatquery =array(


### PR DESCRIPTION
Der Kategorien- und Seitenindex funktioniert bei WordPress 4.8.1 nicht mehr. Es erscheinen Fehlermeldungen wie:

> Notice:  Trying to get property of non-object in wordpress\wp-content\themes\piratenkleider\templates\category-index.php on line 54
> Notice:  Trying to get property of non-object in wordpress\wp-content\themes\piratenkleider\templates\category-index.php on line 88
> Recoverable fatal error:  Object of class WP_Error could not be converted to string in wordpress\wp-includes\formatting.php on line 1031

Anscheinend gab es eine Änderung bei der WordPress-Funktion `get_term_by()`. Der Wert "ID" wird für den Parameter `$field` nicht mehr akzeptiert, es muss "id" sein. Ich habe dies entsprechend angepasst.